### PR TITLE
Allow timeouts to be scaled for slower environments.

### DIFF
--- a/scripts/generate-test-config.sh
+++ b/scripts/generate-test-config.sh
@@ -83,7 +83,8 @@ generate_test_config() {
 	    "path_to_kube_config": "$HOME/.kube/config",
 	    "tls_cert": $(bosh int <(credhub get -n "${director_name}/${deployment}/tls-kubernetes" --output-json) --path='/value/certificate' --json | jq .Blocks[0]),
 	    "tls_private_key": $(bosh int <(credhub get -n "${director_name}/${deployment}/tls-kubernetes" --output-json) --path='/value/private_key' --json | jq .Blocks[0])
-	  }
+	  },
+	  "timeout_scale": $(bosh int $director_yml --path=/timeout_scale 2>/dev/null || echo 1)
 	}
 	EOF
   set -e

--- a/src/tests/config/config.go
+++ b/src/tests/config/config.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Config struct {
-	Bosh       Bosh       `json:"bosh"`
-	Turbulence Turbulence `json:"turbulence"`
-	Cf         Cf         `json:"cf"`
-	Kubernetes Kubernetes `json:"kubernetes"`
+	Bosh         Bosh       `json:"bosh"`
+	Turbulence   Turbulence `json:"turbulence"`
+	Cf           Cf         `json:"cf"`
+	Kubernetes   Kubernetes `json:"kubernetes"`
+	TimeoutScale float64    `json:"timeout_scale"`
 }
 
 type Bosh struct {
@@ -60,6 +61,11 @@ func InitConfig() (*Config, error) {
 	err = json.Unmarshal(configJSON, &config)
 	if err != nil {
 		return nil, err
+	}
+
+	// Do not allow zero for timeout scale as it would fail all the time.
+	if config.TimeoutScale == 0 {
+		config.TimeoutScale = 1
 	}
 
 	return &config, nil

--- a/src/tests/integration-tests/persistent_volume/pod_storage_test.go
+++ b/src/tests/integration-tests/persistent_volume/pod_storage_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Guestbook storage", func() {
 	})
 
 	AfterEach(func() {
-		UndeployGuestBook(kubectl)
+		UndeployGuestBook(kubectl, testconfig.TimeoutScale)
 		kubectl.RunKubectlCommand("delete", "namespace", kubectl.Namespace())
 	})
 
@@ -58,7 +58,7 @@ var _ = Describe("Guestbook storage", func() {
 
 			By("Deploying the persistent application the value is persisted")
 
-			DeployGuestBook(kubectl)
+			DeployGuestBook(kubectl, testconfig.TimeoutScale)
 
 			appAddress := kubectl.GetAppAddress(deployment, "svc/frontend")
 
@@ -73,8 +73,8 @@ var _ = Describe("Guestbook storage", func() {
 
 			By("Un-deploying the application and re-deploying the data is still available from the persisted source")
 
-			UndeployGuestBook(kubectl)
-			DeployGuestBook(kubectl)
+			UndeployGuestBook(kubectl, testconfig.TimeoutScale)
+			DeployGuestBook(kubectl, testconfig.TimeoutScale)
 
 			appAddress = kubectl.GetAppAddress(deployment, "svc/frontend")
 			Eventually(func() string {
@@ -106,7 +106,7 @@ var _ = Describe("Guestbook storage", func() {
 
 			By("Deploying the persistent application the value is persisted")
 
-			DeployGuestBook(kubectl)
+			DeployGuestBook(kubectl, testconfig.TimeoutScale)
 
 			appAddress := kubectl.GetAppAddress(deployment, "svc/frontend")
 
@@ -121,8 +121,8 @@ var _ = Describe("Guestbook storage", func() {
 
 			By("Un-deploying the application and re-deploying the data is still available from the persisted source")
 
-			UndeployGuestBook(kubectl)
-			DeployGuestBook(kubectl)
+			UndeployGuestBook(kubectl, testconfig.TimeoutScale)
+			DeployGuestBook(kubectl, testconfig.TimeoutScale)
 
 			appAddress = kubectl.GetAppAddress(deployment, "svc/frontend")
 			Eventually(func() string {

--- a/src/tests/test_helpers/persistence_helper.go
+++ b/src/tests/test_helpers/persistence_helper.go
@@ -10,18 +10,18 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-func UndeployGuestBook(kubectl *KubectlRunner) {
+func UndeployGuestBook(kubectl *KubectlRunner, timeoutScale float64) {
 	guestBookSpec := PathFromRoot("specs/pv-guestbook.yml")
-	Eventually(kubectl.RunKubectlCommand("delete", "-f", guestBookSpec), "120s").Should(gexec.Exit(0))
+	timeout := time.Duration(float64(2*time.Minute) * timeoutScale)
+	Eventually(kubectl.RunKubectlCommand("delete", "-f", guestBookSpec), timeout).Should(gexec.Exit(0))
 }
 
-func DeployGuestBook(kubectl *KubectlRunner) {
-
+func DeployGuestBook(kubectl *KubectlRunner, timeoutScale float64) {
 	guestBookSpec := PathFromRoot("specs/pv-guestbook.yml")
-	Eventually(kubectl.RunKubectlCommand("apply", "-f", guestBookSpec), "120s").Should(gexec.Exit(0))
-	Eventually(kubectl.RunKubectlCommand("rollout", "status", "deployment/frontend", "-w"), "120s").Should(gexec.Exit(0))
-	Eventually(kubectl.RunKubectlCommand("rollout", "status", "deployment/redis-master", "-w"), "120s").Should(gexec.Exit(0))
-
+	timeout := time.Duration(float64(2*time.Minute) * timeoutScale)
+	Eventually(kubectl.RunKubectlCommand("apply", "-f", guestBookSpec), timeout).Should(gexec.Exit(0))
+	Eventually(kubectl.RunKubectlCommand("rollout", "status", "deployment/frontend", "-w"), timeout).Should(gexec.Exit(0))
+	Eventually(kubectl.RunKubectlCommand("rollout", "status", "deployment/redis-master", "-w"), timeout).Should(gexec.Exit(0))
 }
 
 func PostToGuestBook(address string, testValue string) {

--- a/src/tests/turbulence-tests/persistence_failure/persistence_failure_test.go
+++ b/src/tests/turbulence-tests/persistence_failure/persistence_failure_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Persistence failure scenarios", func() {
 	})
 
 	AfterEach(func() {
-		UndeployGuestBook(kubectl)
+		UndeployGuestBook(kubectl, testconfig.TimeoutScale)
 		pvcSpec := PathFromRoot("specs/persistent-volume-claim.yml")
 		Eventually(kubectl.RunKubectlCommand("delete", "-f", pvcSpec), "60s").Should(gexec.Exit(0))
 		storageClassSpec := PathFromRoot(fmt.Sprintf("specs/storage-class-%s.yml", testconfig.Bosh.Iaas))
@@ -67,7 +67,7 @@ var _ = Describe("Persistence failure scenarios", func() {
 		testValue := strconv.Itoa(rand.Int())
 
 		By("Deploying the persistent application", func() {
-			DeployGuestBook(kubectl)
+			DeployGuestBook(kubectl, testconfig.TimeoutScale)
 			appAddress := kubectl.GetAppAddress(deployment, "svc/frontend")
 
 			PostToGuestBook(appAddress, testValue)
@@ -78,8 +78,8 @@ var _ = Describe("Persistence failure scenarios", func() {
 		})
 
 		By("Un-deploying and re-deploying the app", func() {
-			UndeployGuestBook(kubectl)
-			DeployGuestBook(kubectl)
+			UndeployGuestBook(kubectl, testconfig.TimeoutScale)
+			DeployGuestBook(kubectl, testconfig.TimeoutScale)
 			appAddress := kubectl.GetAppAddress(deployment, "svc/frontend")
 
 			Eventually(func() string {


### PR DESCRIPTION
Add a scale parameter (default to 1) that is used to scale up the timeout of the guestbook app in case of slow environments.

Signed-off-by: Jason Keene <jkeene@pivotal.io>