### PR TITLE
Aligning conformance test timeout to 90m

### DIFF
--- a/src/tests/conformance/conformance_test.go
+++ b/src/tests/conformance/conformance_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Conformance Tests", func() {
 		Eventually(func() string {
 			outputs := kubectl.GetOutput("log", "sonobuoy", "-n", "sonobuoy")
 			return strings.Join(outputs, " ")
-		}, "60m", "1m").Should(ContainSubstring("no-exit was specified, sonobuoy is now blocking"))
+		}, "90m", "1m").Should(ContainSubstring("no-exit was specified, sonobuoy is now blocking"))
 
 		By("Locate test results")
 		session = kubectl.RunKubectlCommandInNamespace("sonobuoy", "log", "sonobuoy")


### PR DESCRIPTION
This change is to align the ginkgo test timeout to the `sonobuoy` timeout that is specified in the YAML file that Kubernetes run

ref: https://github.com/cncf/k8s-conformance/blob/master/sonobuoy-conformance.yaml#L73