### PR TITLE
makes sonobuoy creation timeout configurable

### DIFF
--- a/src/tests/config/config.go
+++ b/src/tests/config/config.go
@@ -84,8 +84,9 @@ type CFCR struct {
 }
 
 type Conformance struct {
-	ResultsDir     string `json:"results_dir"`
-	ReleaseVersion string `json:"release_version"`
+	ResultsDir              string `json:"results_dir"`
+	ReleaseVersion          string `json:"release_version"`
+	SonobuoyCreationTimeout int    `json:"sonobuoy_creation_timeout"`
 }
 
 func InitConfig() (*Config, error) {
@@ -109,6 +110,14 @@ func InitConfig() (*Config, error) {
 	// Do not allow zero for timeout scale as it would fail all the time.
 	if config.TimeoutScale == 0 {
 		config.TimeoutScale = 1
+	}
+
+	if config.Conformance.SonobuoyCreationTimeout < 0 {
+		return nil, errors.New("sonobuoy_create_timeout must be a positive integer")
+	}
+
+	if config.Conformance.SonobuoyCreationTimeout == 0 {
+		config.Conformance.SonobuoyCreationTimeout = 60
 	}
 
 	return &config, nil

--- a/src/tests/conformance/conformance_test.go
+++ b/src/tests/conformance/conformance_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Conformance Tests", func() {
 		Eventually(func() string {
 			outputs := kubectl.GetOutput("get", "pod/sonobuoy", "-n", "sonobuoy", "-o", "jsonpath={.status.phase}")
 			return string(outputs[0])
-		}, "60s", "2s").Should(Equal("Running"))
+		}, testconfig.Conformance.SonobuoyCreationTimeout, "2s").Should(Equal("Running"))
 
 		By("Waiting for conformance tests to complete")
 		Eventually(func() string {


### PR DESCRIPTION
* some infrastructures are slower
* default value is still 60s

Signed-off-by: Kevin Kelani <kkelani@pivotal.io>