### PR TITLE
Retrieve token from oidc enabled cluster

### DIFF
--- a/src/tests/test_helpers/kube_client.go
+++ b/src/tests/test_helpers/kube_client.go
@@ -45,10 +45,23 @@ func IaaS() (string, error) {
 
 func BearerToken() (string, error) {
 	config, err := ReadKubeConfig()
+
 	if err != nil {
 		return "", err
 	}
-	return config.BearerToken, nil
+
+	token := ""
+
+	if config.AuthProvider != nil && config.AuthProvider.Name == "oidc" {
+		token = config.AuthProvider.Config["id-token"]
+	} else {
+		token = config.BearerToken
+	}
+
+	if token == "" {
+		return "", fmt.Errorf("Token is empty")
+	}
+	return token, nil
 }
 
 func GetNodeIP() (string, error) {


### PR DESCRIPTION
[#159132813]

Signed-off-by: Greg Patricio <gpatricio@pivotal.io>

**What this PR does / why we need it**:
Enable the test to be run agains oidc enabled clusters

**How can this PR be verified?**
Run the test against an oidc cluster

**Is there any change in kubo-release?**
no

**Is there any change in kubo-deployment?**
no

**Does this affect upgrade, or is there any migration required?**
no

**Which issue(s) this PR fixes:**
https://github.com/cloudfoundry-incubator/kubo-ci/issues/25

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
It is now   possible to run these tests against an OIDC enabled cluster
```
