### PR TITLE
Make horizontal pod autoscaling timeout configurable

### DIFF
--- a/src/tests/integration-tests/k8s_lbs/external_traffic_policy_test.go
+++ b/src/tests/integration-tests/k8s_lbs/external_traffic_policy_test.go
@@ -68,17 +68,18 @@ var _ = Describe("When deploying a loadbalancer", func() {
 
 			runner.RunKubectlCommandWithTimeout("patch", "svc/echoserver", "-p", "{\"spec\":{\"externalTrafficPolicy\":\"Local\"}}")
 			prefix := segments[0] + "." + segments[1] + "."
+			fmt.Sprintf("prefix: %v", prefix)
 
 			loadbalancerAddress = runner.GetLBAddress("echoserver", iaas)
 			appURL = fmt.Sprintf("http://%s", loadbalancerAddress)
 
-			Eventually(func() string {
-				newPrefix, err := getIPAddressFromEchoserver(appURL)
-				if err != nil {
-					GinkgoWriter.Write([]byte(err.Error()))
-				}
-				return newPrefix
-			}, "600s", "60s").Should(And(Not(BeEmpty()), Not(HavePrefix(prefix))))
+			// Eventually(func() string {
+			// 	newPrefix, err := getIPAddressFromEchoserver(appURL)
+			// 	if err != nil {
+			// 		GinkgoWriter.Write([]byte(err.Error()))
+			// 	}
+			// 	return newPrefix
+			// }, "600s", "60s").Should(And(Not(BeEmpty()), Not(HavePrefix(prefix))))
 		})
 	})
 

--- a/src/tests/integration-tests/k8s_lbs/external_traffic_policy_test.go
+++ b/src/tests/integration-tests/k8s_lbs/external_traffic_policy_test.go
@@ -68,18 +68,17 @@ var _ = Describe("When deploying a loadbalancer", func() {
 
 			runner.RunKubectlCommandWithTimeout("patch", "svc/echoserver", "-p", "{\"spec\":{\"externalTrafficPolicy\":\"Local\"}}")
 			prefix := segments[0] + "." + segments[1] + "."
-			fmt.Sprintf("prefix: %v", prefix)
 
 			loadbalancerAddress = runner.GetLBAddress("echoserver", iaas)
 			appURL = fmt.Sprintf("http://%s", loadbalancerAddress)
 
-			// Eventually(func() string {
-			// 	newPrefix, err := getIPAddressFromEchoserver(appURL)
-			// 	if err != nil {
-			// 		GinkgoWriter.Write([]byte(err.Error()))
-			// 	}
-			// 	return newPrefix
-			// }, "600s", "60s").Should(And(Not(BeEmpty()), Not(HavePrefix(prefix))))
+			Eventually(func() string {
+				newPrefix, err := getIPAddressFromEchoserver(appURL)
+				if err != nil {
+					GinkgoWriter.Write([]byte(err.Error()))
+				}
+				return newPrefix
+			}, "600s", "60s").Should(And(Not(BeEmpty()), Not(HavePrefix(prefix))))
 		})
 	})
 

--- a/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
+++ b/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
@@ -3,6 +3,7 @@ package generic_test
 import (
 	"fmt"
 	"strconv"
+	. "tests/test_helpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -11,6 +12,7 @@ import (
 
 var _ = Describe("Horizontal Pod Autoscaling", func() {
 	It("scales the pods accordingly", func() {
+		HPATimeout := MustHaveEnv("HPA_TIMEOUT")
 		runHPAPod()
 		createHPA()
 
@@ -22,7 +24,7 @@ var _ = Describe("Horizontal Pod Autoscaling", func() {
 			Eventually(session, "10s").Should(gexec.Exit(0))
 			replicas, _ := strconv.Atoi(string(session.Out.Contents()))
 			return replicas
-		}, "210s").Should(BeNumerically(">", 1))
+		}, HPATimeout).Should(BeNumerically(">", 1))
 
 		By("decreasing the number of pods when the CPU load decreases")
 
@@ -34,7 +36,7 @@ var _ = Describe("Horizontal Pod Autoscaling", func() {
 			Eventually(session, "10s").Should(gexec.Exit(0))
 			replicas, _ := strconv.Atoi(string(session.Out.Contents()))
 			return replicas
-		}, "210s").Should(BeNumerically("==", 1))
+		}, HPATimeout).Should(BeNumerically("==", 1))
 	})
 })
 

--- a/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
+++ b/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
@@ -2,8 +2,8 @@ package generic_test
 
 import (
 	"fmt"
+	"os"
 	"strconv"
-	. "tests/test_helpers"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -14,7 +14,7 @@ var defaultHPATimeout = "210s"
 
 var _ = Describe("Horizontal Pod Autoscaling", func() {
 	It("scales the pods accordingly", func() {
-		HPATimeout := MustHaveEnv("HPA_TIMEOUT")
+		HPATimeout := os.Getenv("HPA_TIMEOUT")
 		if HPATimeout == "" {
 			HPATimeout = defaultHPATimeout
 		}

--- a/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
+++ b/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
@@ -10,9 +10,15 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
+var defaultHPATimeout = "210s"
+
 var _ = Describe("Horizontal Pod Autoscaling", func() {
 	It("scales the pods accordingly", func() {
 		HPATimeout := MustHaveEnv("HPA_TIMEOUT")
+		if HPATimeout == "" {
+			HPATimeout = defaultHPATimeout
+		}
+
 		runHPAPod()
 		createHPA()
 

--- a/tasks/run-k8s-integration-tests.yml
+++ b/tasks/run-k8s-integration-tests.yml
@@ -16,6 +16,7 @@ params:
   ENABLE_CIDR_TESTS: false
   CIDR_VARS_FILE: manifests/vars-files/default-cidrs.yml
   KUBECONFIG_FILE: config
+  HPA_TIMEOUT: 210s
 
 inputs:
   - name: git-kubo-ci


### PR DESCRIPTION
[#159886658]

Signed-off-by: Carlo Colombo <ccolombo@pivotal.io>

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

The timeout for horizontal pod autoscaling is less then the default and this fails our tests which rely on a more robust deployment. We would like to make the horizontal pod autoscaling configurable.

**How can this PR be verified?**

We have run this through our pipeline where we run CFCR integration tests as part of the pipeline, and we have passed in configuration with a higher timeout.

**Is there any change in kubo-release?**

No

**Is there any change in kubo-deployment?**

No

**Does this affect upgrade, or is there any migration required?**

No

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
