### PR TITLE
Using managed style for disk (to match worker's ones)

### DIFF
--- a/specs/storage-class-azure.yml
+++ b/specs/storage-class-azure.yml
@@ -5,5 +5,5 @@ metadata:
 provisioner: kubernetes.io/azure-disk
 parameters:
   skuname: Standard_LRS
-  kind: shared
+  kind: managed
   cachingmode: None


### PR DESCRIPTION
[#161091578]

Signed-off-by: Nikita Rathi <nrathi@pivotal.io>

Deploying cfcr with persistent disk bosh attach azure managed disk, azure requires that all the disk attached to a vm match the first one attached.