### PR TITLE
Improvements to kubo-windows pipeline

### DIFF
--- a/kubo-windows.yml
+++ b/kubo-windows.yml
@@ -241,6 +241,7 @@ jobs:
       - git-kubo-deployment/manifests/ops-files/iaas/vsphere/cloud-provider.yml
       - git-kubo-deployment/manifests/ops-files/iaas/vsphere/use-vm-extensions.yml
       - git-kubo-deployment/manifests/ops-files/use-hostgw.yml
+      - git-kubo-deployment/manifests/ops-files/addons-spec.yml
       - git-kubo-deployment/manifests/ops-files/windows/add-worker.yml
       - git-kubo-deployment/manifests/ops-files/windows/scale-to-one-az.yml
       - git-kubo-deployment/manifests/ops-files/windows/use-hostgw.yml
@@ -256,6 +257,8 @@ jobs:
       vars:
         deployment_name: ci-service
         worker_count: 3
+      var_files:
+        addons-spec: "git-kubo-ci/specs/guestbook.yml"
       vars_files:
       - gcs-load-balancer-vars/load-balancer-vars.yml
       - kubo-lock/metadata

--- a/kubo-windows.yml
+++ b/kubo-windows.yml
@@ -244,6 +244,9 @@ jobs:
       - git-kubo-deployment/manifests/ops-files/windows/add-worker.yml
       - git-kubo-deployment/manifests/ops-files/windows/scale-to-one-az.yml
       - git-kubo-deployment/manifests/ops-files/windows/use-hostgw.yml
+      - git-kubo-deployment/manifests/ops-files/windows/use-runtime-config-bosh-dns.yml
+      - git-kubo-deployment/manifests/ops-files/iaas/vsphere/windows/cloud-provider.yml
+      - git-kubo-deployment/manifests/ops-files/iaas/vsphere/windows/use-vm-extensions.yml
       releases:
       - kubo-release/release.tgz
       source_file: source-json/source.json

--- a/kubo-windows.yml
+++ b/kubo-windows.yml
@@ -331,6 +331,7 @@ jobs:
       ENABLE_MULTI_AZ_TESTS: true
       ENABLE_OSS_ONLY_TESTS: true
       ENABLE_PERSISTENT_VOLUME_TESTS: true
+      SKIP_PACKAGES: persistent_volume,scaling
     tags:
     - vsphere-lb
   on_failure:

--- a/kubo-windows.yml
+++ b/kubo-windows.yml
@@ -245,7 +245,6 @@ jobs:
       - git-kubo-deployment/manifests/ops-files/windows/add-worker.yml
       - git-kubo-deployment/manifests/ops-files/windows/scale-to-one-az.yml
       - git-kubo-deployment/manifests/ops-files/windows/use-hostgw.yml
-      - git-kubo-deployment/manifests/ops-files/windows/use-runtime-config-bosh-dns.yml
       - git-kubo-deployment/manifests/ops-files/iaas/vsphere/windows/cloud-provider.yml
       - git-kubo-deployment/manifests/ops-files/iaas/vsphere/windows/use-vm-extensions.yml
       releases:

--- a/scripts/run-k8s-integration-tests.sh
+++ b/scripts/run-k8s-integration-tests.sh
@@ -15,7 +15,7 @@ main() {
   mkdir -p ~/.kube
   cp ${kubeconfig} ~/.kube/config
 
-  skipped_packages=""
+  skipped_packages=",${SKIP_PACKAGES}"
 
   if [[ "${ENABLE_MULTI_AZ_TESTS:-false}" == "false" ]]; then
     skipped_packages="$skipped_packages,multiaz"

--- a/specs/windows/webserver.yml
+++ b/specs/windows/webserver.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windows-webserver
+spec:
+  nodeSelector:
+    beta.kubernetes.io/os: windows
+  tolerations:
+  - key: "windows"
+    operator: "Equal"
+    value: "1803"
+    effect: "NoSchedule"
+  restartPolicy: Always
+  containers:
+  - image: microsoft/windowsservercore:1803
+    name: webserver
+    command:
+    - powershell.exe
+    - -command
+    - "<#code used from https://gist.github.com/wagnerandrade/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callCount = 0; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ; $$content='Windows Container Web Server\nHello world!\n'; Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "

--- a/src/tests/integration-tests/windows/windows_suite_test.go
+++ b/src/tests/integration-tests/windows/windows_suite_test.go
@@ -1,0 +1,22 @@
+package windows_test
+
+import (
+	"testing"
+	"tests/test_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var hasWindowsWorkers bool
+
+var _ = BeforeSuite(func() {
+	var err error
+	hasWindowsWorkers, err = test_helpers.HasWindowsWorkers()
+	Expect(err).To(BeNil())
+})
+
+func TestWindows(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Windows Suite")
+}

--- a/src/tests/integration-tests/windows/windows_test.go
+++ b/src/tests/integration-tests/windows/windows_test.go
@@ -1,0 +1,42 @@
+package windows_test
+
+import (
+	"tests/test_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var runner *test_helpers.KubectlRunner
+
+var _ = Describe("When deploying to a Windows worker", func() {
+	BeforeEach(func() {
+		if !hasWindowsWorkers {
+			Skip("skipping Windows tests since no Windows nodes were detected")
+		}
+		runner = test_helpers.NewKubectlRunner()
+		runner.Setup()
+	})
+	AfterEach(func() {
+		runner.Teardown()
+	})
+
+	var (
+		webServerSpec = test_helpers.PathFromRoot("specs/windows/webserver.yml")
+	)
+
+	BeforeEach(func() {
+		deploy := runner.RunKubectlCommand("create", "-f", webServerSpec)
+		Eventually(deploy, "60s").Should(gexec.Exit(0))
+		rolloutWatch := runner.RunKubectlCommand("wait", "--for=condition=ready", "pod/windows-webserver")
+		Eventually(rolloutWatch, "120s").Should(gexec.Exit(0))
+	})
+
+	AfterEach(func() {
+		runner.RunKubectlCommand("delete", "-f", webServerSpec)
+	})
+	It("should be able to fetch logs from the pod", func() {
+		Eventually(func() ([]string, error) { return runner.GetOutput("logs", "windows-webserver") }, "31s").Should(ConsistOf("Listening", "at", "http://*:80/"))
+	})
+})

--- a/src/tests/test_helpers/kube_client.go
+++ b/src/tests/test_helpers/kube_client.go
@@ -111,3 +111,17 @@ func CreateTestNamespace(k8s k8s.Interface, prefix string) (*corev1.Namespace, e
 func DeleteTestNamespace(k8s k8s.Interface, namespace string) error {
 	return k8s.CoreV1().Namespaces().Delete(namespace, &meta_v1.DeleteOptions{})
 }
+
+func HasWindowsWorkers() (bool, error) {
+	nodes, err := GetNodes()
+	if err != nil {
+		return false, err
+	}
+
+	for _, n := range nodes.Items {
+		if n.Status.NodeInfo.OperatingSystem == "windows" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/tasks/run-k8s-integration-tests.yml
+++ b/tasks/run-k8s-integration-tests.yml
@@ -16,6 +16,7 @@ params:
   CIDR_VARS_FILE: manifests/vars-files/default-cidrs.yml
   KUBECONFIG_FILE: config
   HPA_TIMEOUT: 210s
+  SKIP_PACKAGES:
 
 inputs:
   - name: git-kubo-ci


### PR DESCRIPTION
- Add vsphere cloud-provider ops-files for windows
- Add guestbook spec to apply-addons
- Add basic windows test, but make it correctly skip (not fail) when run against a non-Windows cluster