### PR TITLE
V0.25.0 fix

### DIFF
--- a/src/tests/integration-tests/external_traffic_policy/external_traffic_policy_test.go
+++ b/src/tests/integration-tests/external_traffic_policy/external_traffic_policy_test.go
@@ -58,7 +58,7 @@ var _ = Describe("When deploying a loadbalancer", func() {
 			Eventually(func() string {
 				loadbalancerAddress = kubectl.GetLBAddress("echoserver", iaas)
 				return loadbalancerAddress
-			}, "240s", kubectl.TimeoutInSeconds).Should(Not(Equal("")))
+			}, "640s", kubectl.TimeoutInSeconds).Should(Not(Equal("")))
 
 			By("getting the source IP from echoserver")
 			appURL := fmt.Sprintf("http://%s", loadbalancerAddress)

--- a/src/tests/integration-tests/external_traffic_policy/external_traffic_policy_test.go
+++ b/src/tests/integration-tests/external_traffic_policy/external_traffic_policy_test.go
@@ -58,7 +58,7 @@ var _ = Describe("When deploying a loadbalancer", func() {
 			Eventually(func() string {
 				loadbalancerAddress = kubectl.GetLBAddress("echoserver", iaas)
 				return loadbalancerAddress
-			}, "640s", kubectl.TimeoutInSeconds).Should(Not(Equal("")))
+			}, 8*kubectl.TimeoutInSeconds, kubectl.TimeoutInSeconds).Should(Not(Equal("")))
 
 			By("getting the source IP from echoserver")
 			appURL := fmt.Sprintf("http://%s", loadbalancerAddress)

--- a/src/tests/integration-tests/k8s_lbs/deploy_workload_test.go
+++ b/src/tests/integration-tests/k8s_lbs/deploy_workload_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Deploy workload", func() {
 		Eventually(func() string {
 			loadbalancerAddress = kubectl.GetLBAddress("nginx", iaas)
 			return loadbalancerAddress
-		}, "600s", "5s").Should(Not(Equal("")))
+		}, 10*kubectl.TimeoutInSeconds, "5s").Should(Not(Equal("")))
 
 		appUrl := fmt.Sprintf("http://%s", loadbalancerAddress)
 

--- a/src/tests/integration-tests/k8s_lbs/deploy_workload_test.go
+++ b/src/tests/integration-tests/k8s_lbs/deploy_workload_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Deploy workload", func() {
 		Eventually(func() string {
 			loadbalancerAddress = kubectl.GetLBAddress("nginx", iaas)
 			return loadbalancerAddress
-		}, "240s", "5s").Should(Not(Equal("")))
+		}, "600s", "5s").Should(Not(Equal("")))
 
 		appUrl := fmt.Sprintf("http://%s", loadbalancerAddress)
 

--- a/src/tests/integration-tests/persistent_volume/nfs_test.go
+++ b/src/tests/integration-tests/persistent_volume/nfs_test.go
@@ -81,7 +81,7 @@ var _ = Describe("NFS", func() {
 		})
 
 		It("should mount an NFS PV to a workload", func() {
-			WaitForPodsToRun(kubectl, kubectl.TimeoutInSeconds*2)
+			WaitForPodsToRun(kubectl, kubectl.TimeoutInSeconds*3)
 		})
 	})
 })

--- a/src/tests/integration-tests/persistent_volume/pod_storage_test.go
+++ b/src/tests/integration-tests/persistent_volume/pod_storage_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"time"
 
 	. "tests/test_helpers"
 
@@ -73,6 +74,7 @@ var _ = Describe("Guestbook storage", func() {
 			By("Un-deploying the application and re-deploying the data is still available from the persisted source")
 
 			UndeployGuestBook(kubectl)
+			time.Sleep(30 * time.Second)
 			DeployGuestBook(kubectl)
 
 			By("Getting the value from application")


### PR DESCRIPTION
A couple of timeout that are failing mostly on azure have been increased, also some add some time between undeploying and redeploying the guestbook checking for disk to be reattached