### PR TITLE
Fix hostport test to check that curl exits successfully

### DIFF
--- a/src/tests/integration-tests/generic/hostport_test.go
+++ b/src/tests/integration-tests/generic/hostport_test.go
@@ -40,10 +40,14 @@ var _ = Describe("When deploying a pod with service", func() {
 			hostIP, err := kubectl.GetOutput("get", "pod", "-l", "app=nginx-hostport",
 				"-o", "jsonpath='{@.items[0].status.hostIP}'")
 			Expect(err).NotTo(HaveOccurred())
-			url := fmt.Sprintf("http://%s:40801", hostIP)
+			url := fmt.Sprintf("http://%s:40801", hostIP[0])
 			session := kubectl.StartKubectlCommand("run", "curl-hostport",
 				"--image=tutum/curl", "--restart=Never", "--", "curl", url)
 			Eventually(session, "10s").Should(gexec.Exit(0))
+
+			Eventually(func() ([]string, error) {
+				return kubectl.GetOutput("get", "pod/curl-hostport", "-o", "jsonpath='{.status.phase}'")
+			}, "30s").Should(ConsistOf("Succeeded"))
 		})
 	})
 })

--- a/src/tests/test_helpers/kubectl_runner.go
+++ b/src/tests/test_helpers/kubectl_runner.go
@@ -18,6 +18,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const outputCutset = `"'`
+
 type KubectlRunner struct {
 	configPath       string
 	namespace        string
@@ -112,7 +114,7 @@ func (kubectl *KubectlRunner) GetOutputBytes(kubectlArgs ...string) []byte {
 	session := kubectl.StartKubectlCommand(kubectlArgs...)
 	Eventually(session, kubectl.TimeoutInSeconds).Should(gexec.Exit(0))
 	output := session.Out.Contents()
-	return bytes.Trim(output, `"`)
+	return bytes.Trim(output, outputCutset)
 }
 
 func (kubectl *KubectlRunner) GetOutputBytesOrError(kubectlArgs ...string) ([]byte, error) {
@@ -122,7 +124,7 @@ func (kubectl *KubectlRunner) GetOutputBytesOrError(kubectlArgs ...string) ([]by
 		return []byte{}, fmt.Errorf("kubectl command exitted with non zero exit code: %d", session.ExitCode())
 	}
 	output := session.Out.Contents()
-	return bytes.Trim(output, `"`), nil
+	return bytes.Trim(output, outputCutset), nil
 }
 
 func (kubectl *KubectlRunner) GetOutputBytesInNamespace(namespace string, kubectlArgs ...string) []byte {
@@ -134,7 +136,7 @@ func (kubectl *KubectlRunner) GetOutputBytesInNamespace(namespace string, kubect
 		return session.ExitCode()
 	}, kubectl.TimeoutInSeconds, "30s").Should(Equal(0))
 	output := session.Out.Contents()
-	return bytes.Trim(output, `"`)
+	return bytes.Trim(output, outputCutset)
 }
 
 func (kubectl *KubectlRunner) GetNodePort(service string) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This test wasn't doing what it seemed was the intention: to ensure that hostport connectivity is working. I had to change the calls to `bytes.Trim` because I was seeing `'` characters around all the `kubectl` output. I'm not sure why, when I ran those commands in a terminal they didn't look quoted.

I couldn't successfully run the whole suite, but I think it's because I just don't have a cluster that's in the right state for these tests to all run against. There seems to be some assumptions about cluster configuration and things already having been deployed beyond what comes with the `apply-specs` errand.

**How can this PR be verified?**
Run the suite!

**Is there any change in kubo-release?**
Nope

**Is there any change in kubo-deployment?**
Nope

**Does this affect upgrade, or is there any migration required?**
Nope

**Which issue(s) this PR fixes:**
#44

**Release note**:
```release-note
NONE
```
