### PR TITLE
Windows Test Coverage

### DIFF
--- a/specs/windows/webserver.yml
+++ b/specs/windows/webserver.yml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: windows-webserver
+  labels:
+    app: windows-webserver
 spec:
   nodeSelector:
     beta.kubernetes.io/os: windows
@@ -15,7 +17,10 @@ spec:
   containers:
   - image: microsoft/windowsservercore:1803
     name: webserver
+    ports:
+    - name: http
+      containerPort: 80
     command:
     - powershell.exe
     - -command
-    - "<#code used from https://gist.github.com/wagnerandrade/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callCount = 0; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ; $$content='Windows Container Web Server\nHello world!\n'; Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "
+    - "<#code used from https://gist.github.com/wagnerandrade/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callCount = 0; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ; $$content='Windows Container Web Server\n'; Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "

--- a/specs/windows/webserver.yml
+++ b/specs/windows/webserver.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: windows-webserver
+spec:
+  nodeSelector:
+    beta.kubernetes.io/os: windows
+  tolerations:
+  - key: "windows"
+    operator: "Equal"
+    value: "1803"
+    effect: "NoSchedule"
+  restartPolicy: Always
+  containers:
+  - image: microsoft/windowsservercore:1803
+    name: webserver
+    command:
+    - powershell.exe
+    - -command
+    - "<#code used from https://gist.github.com/wagnerandrade/5424431#> ; $$listener = New-Object System.Net.HttpListener ; $$listener.Prefixes.Add('http://*:80/') ; $$listener.Start() ; $$callCount = 0; Write-Host('Listening at http://*:80/') ; while ($$listener.IsListening) { ;$$context = $$listener.GetContext() ;$$requestUrl = $$context.Request.Url ;$$response = $$context.Response ;Write-Host '' ;Write-Host('> {0}' -f $$requestUrl) ; $$content='Windows Container Web Server\nHello world!\n'; Write-Output $$content ;$$buffer = [System.Text.Encoding]::UTF8.GetBytes($$content) ;$$response.ContentLength64 = $$buffer.Length ;$$response.OutputStream.Write($$buffer, 0, $$buffer.Length) ;$$response.Close() ;$$responseStatus = $$response.StatusCode ;Write-Host('< {0}' -f $$responseStatus)  } ; "

--- a/src/tests/integration-tests/windows/windows_suite_test.go
+++ b/src/tests/integration-tests/windows/windows_suite_test.go
@@ -1,0 +1,22 @@
+package windows_test
+
+import (
+	"testing"
+	"tests/test_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var hasWindowsWorkers bool
+
+var _ = BeforeSuite(func() {
+	var err error
+	hasWindowsWorkers, err = test_helpers.HasWindowsWorkers()
+	Expect(err).To(BeNil())
+})
+
+func TestWindows(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Windows Suite")
+}

--- a/src/tests/integration-tests/windows/windows_test.go
+++ b/src/tests/integration-tests/windows/windows_test.go
@@ -1,0 +1,42 @@
+package windows_test
+
+import (
+	"tests/test_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var runner *test_helpers.KubectlRunner
+
+var _ = Describe("When deploying to a Windows worker", func() {
+	BeforeEach(func() {
+		if !hasWindowsWorkers {
+			Skip("skipping Windows tests since no Windows nodes were detected")
+		}
+		runner = test_helpers.NewKubectlRunner()
+		runner.Setup()
+	})
+	AfterEach(func() {
+		runner.Teardown()
+	})
+
+	var (
+		webServerSpec = test_helpers.PathFromRoot("specs/windows/webserver.yml")
+	)
+
+	BeforeEach(func() {
+		deploy := runner.RunKubectlCommand("create", "-f", webServerSpec)
+		Eventually(deploy, "60s").Should(gexec.Exit(0))
+		rolloutWatch := runner.RunKubectlCommand("wait", "--for=condition=ready", "pod/windows-webserver")
+		Eventually(rolloutWatch, "120s").Should(gexec.Exit(0))
+	})
+
+	AfterEach(func() {
+		runner.RunKubectlCommand("delete", "-f", webServerSpec)
+	})
+	It("should be able to fetch logs from the pod", func() {
+		Eventually(func() ([]string, error) { return runner.GetOutput("logs", "windows-webserver") }, "31s").Should(ConsistOf("Listening", "at", "http://*:80/"))
+	})
+})

--- a/src/tests/integration-tests/windows/windows_test.go
+++ b/src/tests/integration-tests/windows/windows_test.go
@@ -1,6 +1,7 @@
 package windows_test
 
 import (
+	"fmt"
 	"tests/test_helpers"
 
 	. "github.com/onsi/ginkgo"
@@ -8,35 +9,71 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var runner *test_helpers.KubectlRunner
+var (
+	kubectl       *test_helpers.KubectlRunner
+	webServerSpec = test_helpers.PathFromRoot("specs/windows/webserver.yml")
+)
 
 var _ = Describe("When deploying to a Windows worker", func() {
 	BeforeEach(func() {
 		if !hasWindowsWorkers {
 			Skip("skipping Windows tests since no Windows nodes were detected")
 		}
-		runner = test_helpers.NewKubectlRunner()
-		runner.Setup()
-	})
-	AfterEach(func() {
-		runner.Teardown()
-	})
-
-	var (
-		webServerSpec = test_helpers.PathFromRoot("specs/windows/webserver.yml")
-	)
-
-	BeforeEach(func() {
-		deploy := runner.RunKubectlCommand("create", "-f", webServerSpec)
+		kubectl = test_helpers.NewKubectlRunner()
+		kubectl.Setup()
+		deploy := kubectl.StartKubectlCommand("create", "-f", webServerSpec)
 		Eventually(deploy, "60s").Should(gexec.Exit(0))
-		rolloutWatch := runner.RunKubectlCommand("wait", "--for=condition=ready", "pod/windows-webserver")
-		Eventually(rolloutWatch, "120s").Should(gexec.Exit(0))
+		Eventually(kubectl.StartKubectlCommand("wait", "--timeout=120s",
+			"--for=condition=ready", "pod/windows-webserver"), "120s").Should(gexec.Exit(0))
 	})
 
 	AfterEach(func() {
-		runner.RunKubectlCommand("delete", "-f", webServerSpec)
+		kubectl.Teardown()
 	})
-	It("should be able to fetch logs from the pod", func() {
-		Eventually(func() ([]string, error) { return runner.GetOutput("logs", "windows-webserver") }, "31s").Should(ConsistOf("Listening", "at", "http://*:80/"))
+
+	It("should be able to fetch logs from a pod", func() {
+		Eventually(func() ([]string, error) {
+			return kubectl.GetOutput("logs", "windows-webserver")
+		}, "30s").Should(Equal([]string{"Listening", "at", "http://*:80/"}))
+	})
+
+	Context("when exposed by NodePort service", func() {
+		BeforeEach(func() {
+			expose := kubectl.StartKubectlCommand("expose", "pod", "windows-webserver", "--type", "NodePort")
+			Eventually(expose, "30s").Should(gexec.Exit(0))
+		})
+
+		It("should be reachable by NodePort", func() {
+			hostIP := kubectl.GetOutputBytes("get", "pod", "-l", "app=windows-webserver",
+				"-o", "jsonpath='{.items[0].status.hostIP}'")
+			nodePort := kubectl.GetOutputBytes("get", "service", "windows-webserver",
+				"-o", "jsonpath='{.spec.ports[0].nodePort}'")
+			url := fmt.Sprintf("http://%s:%s", hostIP, nodePort)
+
+			Eventually(curl(url), "30s").Should(ConsistOf("Windows", "Container", "Web", "Server"))
+		})
+
+		It("should be reachable by ClusterIP", func() {
+			clusterIP := kubectl.GetOutputBytes("get", "service", "windows-webserver",
+				"-o", "jsonpath='{.spec.clusterIP}'")
+			url := fmt.Sprintf("http://%s", clusterIP)
+
+			Eventually(curl(url), "30s").Should(ConsistOf("Windows", "Container", "Web", "Server"))
+		})
 	})
 })
+
+func curl(url string) func() ([]string, error) {
+	Eventually(
+		kubectl.StartKubectlCommand("run", "curl", "--image=tutum/curl", "--restart=OnFailure",
+			"--", "curl", "-s", url),
+	).Should(gexec.Exit(0))
+
+	Eventually(func() ([]string, error) {
+		return kubectl.GetOutput("get", "pod", "-l", "job-name=curl", "-o", "jsonpath='{.items[0].status.phase}")
+	}, "30s").Should(ConsistOf("Succeeded"))
+
+	return func() ([]string, error) {
+		return kubectl.GetOutput("logs", "-l", "job-name=curl")
+	}
+}

--- a/src/tests/test_helpers/kube_client.go
+++ b/src/tests/test_helpers/kube_client.go
@@ -111,3 +111,17 @@ func CreateTestNamespace(k8s k8s.Interface, prefix string) (*corev1.Namespace, e
 func DeleteTestNamespace(k8s k8s.Interface, namespace string) error {
 	return k8s.CoreV1().Namespaces().Delete(namespace, &meta_v1.DeleteOptions{})
 }
+
+func HasWindowsWorkers() (bool, error) {
+	nodes, err := GetNodes()
+	if err != nil {
+		return false, err
+	}
+
+	for _, n := range nodes.Items {
+		if n.Status.NodeInfo.OperatingSystem == "windows" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/src/tests/test_helpers/kubectl_runner.go
+++ b/src/tests/test_helpers/kubectl_runner.go
@@ -121,7 +121,7 @@ func (kubectl *KubectlRunner) GetOutputBytesOrError(kubectlArgs ...string) ([]by
 	session := kubectl.StartKubectlCommand(kubectlArgs...)
 	Eventually(session, kubectl.TimeoutInSeconds).Should(gexec.Exit())
 	if session.ExitCode() != 0 {
-		return []byte{}, fmt.Errorf("kubectl command exitted with non zero exit code: %d", session.ExitCode())
+		return []byte{}, fmt.Errorf("kubectl command exited with non zero exit code: %d", session.ExitCode())
 	}
 	output := session.Out.Contents()
 	return bytes.Trim(output, outputCutset), nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds tests for Windows nodes (that only run when the cluster has windows nodes) in pursuit of merging windows support into CFCR.

**How can this PR be verified?**
Given a cluster deployed with windows nodes, running `ginkgo -v src/tests/integration-tests/windows` will show 3 passing tests. (On Linux-only clusters, it will show 3 skipped tests.)

**Is there any change in kubo-release?**
Not yet.
**Is there any change in kubo-deployment?**
Not yet.
**Does this affect upgrade, or is there any migration required?**
No.

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
