### PR TITLE
Test emptyDir volumes are actually mounted under /var/vcap/data/kubelet

### DIFF
--- a/scripts/run-k8s-integration-tests.sh
+++ b/scripts/run-k8s-integration-tests.sh
@@ -30,7 +30,7 @@ main() {
   fi
 
   if [[ "${ENABLE_PERSISTENT_VOLUME_TESTS:-false}" == "false" ]]; then
-    skipped_packages="$skipped_packages,persistent_volume"
+    skipped_packages="$skipped_packages,volume"
   fi
 
   if [[ "${ENABLE_K8S_LBS_TESTS:-false}" == "false" ]]; then

--- a/specs/pod-emptydir.yml
+++ b/specs/pod-emptydir.yml
@@ -101,4 +101,3 @@ spec:
     stdin: true
     command: ["/bin/sh"]
 
-    # ["-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]"]

--- a/specs/pod-emptydir.yml
+++ b/specs/pod-emptydir.yml
@@ -1,0 +1,104 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: testpod-sa
+
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: testpod-psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  - min: 0
+    max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp:testpod-psp
+rules:
+- apiGroups:
+  - extensions
+  resourceNames:
+  - testpod-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp:testpod-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: psp:testpod-psp
+subjects:
+- kind: ServiceAccount
+  name: testpod-sa
+
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: emptydir-pod
+spec:
+  serviceAccountName: testpod-sa
+
+  volumes:
+  - name: simple-vol
+    emptyDir: {}
+  - name: search-vol
+    hostPath:
+      path: /var/vcap/data/kubelet
+
+  initContainers:
+  - name: writing-container
+    volumeMounts:
+    - name: simple-vol
+      mountPath: /var/simple
+
+    image: alpine
+    command: ["/bin/sh"]
+    args: ["-c", "touch /var/simple/find_me.txt"]
+
+  containers:
+  - name: shell-container
+    volumeMounts:
+    - name: simple-vol
+      mountPath: /var/simple
+    - name: search-vol
+      mountPath: /var/search
+    image: alpine
+    tty: true
+    stdin: true
+    command: ["/bin/sh"]
+
+    # ["-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]"]

--- a/src/tests/integration-tests/pod/emptydir_test.go
+++ b/src/tests/integration-tests/pod/emptydir_test.go
@@ -1,0 +1,40 @@
+package pod_test
+
+import (
+	. "tests/test_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("a pod emptyDir volume should be mounted under /var/vcap/data/kubelet", func() {
+	kubectl := NewKubectlRunner()
+
+	BeforeEach(func() {
+		kubectl.Setup()
+	})
+
+	AfterEach(func() {
+		kubectl.Teardown()
+	})
+
+	Context("when an emptyDir volume has been mounted in a container", func() {
+		podSpecPath := PathFromRoot("specs/pod-emptydir.yml")
+
+		BeforeEach(func() {
+			Eventually(kubectl.StartKubectlCommand("apply", "-f", podSpecPath), kubectl.TimeoutInSeconds).Should(gexec.Exit(0))
+		})
+
+		AfterEach(func() {
+			Eventually(kubectl.StartKubectlCommand("delete", "-f", podSpecPath), kubectl.TimeoutInSeconds).Should(gexec.Exit())
+		})
+
+		It("should appear on the host under a /var/vcap/data/kubelet subdirectory", func() {
+			WaitForPodsToRun(kubectl, kubectl.TimeoutInSeconds*3)
+
+			Eventually(kubectl.StartKubectlCommand("exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]")).Should(gexec.Exit(0))
+		})
+	})
+})

--- a/src/tests/integration-tests/volume/azure_file_test.go
+++ b/src/tests/integration-tests/volume/azure_file_test.go
@@ -1,4 +1,4 @@
-package persistent_volume_test
+package volume_test
 
 import (
 	. "tests/test_helpers"

--- a/src/tests/integration-tests/volume/emptydir_test.go
+++ b/src/tests/integration-tests/volume/emptydir_test.go
@@ -1,4 +1,4 @@
-package pod_test
+package volume_test
 
 import (
 	. "tests/test_helpers"
@@ -34,7 +34,7 @@ var _ = Describe("a pod emptyDir volume should be mounted under /var/vcap/data/k
 		It("should appear on the host under a /var/vcap/data/kubelet subdirectory", func() {
 			WaitForPodsToRun(kubectl, kubectl.TimeoutInSeconds*3)
 
-			Eventually(kubectl.StartKubectlCommand("exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]")).Should(gexec.Exit(0))
+			Eventually(kubectl.StartKubectlCommand("exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]"), kubectl.TimeoutInSeconds).Should(gexec.Exit(0))
 		})
 	})
 })

--- a/src/tests/integration-tests/volume/nfs_test.go
+++ b/src/tests/integration-tests/volume/nfs_test.go
@@ -1,4 +1,4 @@
-package persistent_volume_test
+package volume_test
 
 import (
 	"fmt"

--- a/src/tests/integration-tests/volume/pod_storage_test.go
+++ b/src/tests/integration-tests/volume/pod_storage_test.go
@@ -1,4 +1,4 @@
-package persistent_volume_test
+package volume_test
 
 import (
 	"fmt"

--- a/src/tests/integration-tests/volume/volume_suite_test.go
+++ b/src/tests/integration-tests/volume/volume_suite_test.go
@@ -1,4 +1,4 @@
-package persistent_volume_test
+package volume_test
 
 import (
 	. "github.com/onsi/ginkgo"


### PR DESCRIPTION
**What this PR does / why we need it**:
Need to test if kubelet `--root-dir` parameter is actually applied. See cloudfoundry-incubator/kubo-deployment#384

**How can this PR be verified?**
Hopefully, by looking at a test pipeline.

**Is there any change in kubo-release?**
Nope

**Is there any change in kubo-deployment?**
cloudfoundry-incubator/kubo-deployment#384

**Does this affect upgrade, or is there any migration required?**
Nope

**Which issue(s) this PR fixes:**
Adds a test for cloudfoundry-incubator/kubo-deployment#384

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
