### PR TITLE
Auto-bump windows releases.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,5 @@
+Copyright 2022 VMware, Inc.
+
+This product is licensed to you under the BSD 2 clause (the "License"). You may not use this product except in compliance with the License.
+
+This product may include a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file.

--- a/bump-bosh-releases.yml
+++ b/bump-bosh-releases.yml
@@ -39,6 +39,17 @@ resources:
   source:
     repository: cloudfoundry-incubator/docker-boshrelease
 
+- name: windows-tools-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry/windows-tools-release
+
+- name: windows-utilities-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry-incubator/windows-utilities-release
+
+
 - name: gcs-precompiled-cfcr-etcd-untested
   type: gcs
   source:
@@ -205,6 +216,46 @@ jobs:
       git-kubo-deployment: git-kubo-deployment-output
     params:
       RELEASE_LIST: "docker"
+  - put: git-kubo-deployment
+    params:
+      repository: git-kubo-deployment-output
+
+- name: bump-windows-tools-release
+  plan:
+  - aggregate:
+    - get: git-kubo-ci
+    - get: git-kubo-deployment
+    - get: gcs-source-json
+    - get: windows-tools-release
+      trigger: true
+  - task: bump-windows-tools-release
+    file: git-kubo-ci/tasks/bump-boshrelease.yml
+    input_mapping:
+       boshrelease: windows-tools-release
+    params:
+      RELEASE_NAME: windows-tools
+      MODE: name
+      OPSFILE: windows/add-worker.yml
+  - put: git-kubo-deployment
+    params:
+      repository: git-kubo-deployment-output
+
+- name: bump-windows-utilities-release
+  plan:
+  - aggregate:
+    - get: git-kubo-ci
+    - get: git-kubo-deployment
+    - get: gcs-source-json
+    - get: windows-utilities-release
+      trigger: true
+  - task: bump-windows-utilities-release
+    file: git-kubo-ci/tasks/bump-boshrelease.yml
+    input_mapping:
+       boshrelease: windows-utilities-release
+    params:
+      RELEASE_NAME: windows-utilities
+      MODE: name
+      OPSFILE: windows/enable-rdp.yml
   - put: git-kubo-deployment
     params:
       repository: git-kubo-deployment-output

--- a/scripts/bump-boshrelease.sh
+++ b/scripts/bump-boshrelease.sh
@@ -6,12 +6,25 @@ cp -r git-kubo-deployment/. git-kubo-deployment-output
 
 release="${RELEASE_NAME}"
 version="$(cat boshrelease/version)"
+opsfile="${OPSFILE:-non-precompiled-release.yml}"
+mode="${MODE}"
 
 url="$(cat boshrelease/url)"
 
 sha1="$(cat boshrelease/sha1)"
 
-cat > update-$release-release.yml <<EOF
+if [ "$mode" == "name" ]; then
+  cat > update-$release-release.yml <<EOF
+- type: replace
+  path: /name=$release/value
+  value:
+    name: $release
+    version: $version
+    sha1: $sha1
+    url: $url
+EOF
+else
+  cat > update-$release-release.yml <<EOF
 - type: replace
   path: /0/value/name=$release
   value:
@@ -20,17 +33,18 @@ cat > update-$release-release.yml <<EOF
     sha1: $sha1
     url: $url
 EOF
+fi
 
-bosh int git-kubo-deployment/manifests/ops-files/non-precompiled-releases.yml \
-  -o update-$release-release.yml > git-kubo-deployment-output/manifests/ops-files/non-precompiled-releases.yml
+bosh int "git-kubo-deployment/manifests/ops-files/$opsfile" \
+  -o update-$release-release.yml > "git-kubo-deployment-output/manifests/ops-files/$opsfile"
 
 pushd git-kubo-deployment-output
 git config --global user.name "cfcr"
 git config --global user.email "cfcr@pivotal.io"
 
 if [ -n "$(git status --porcelain)" ]; then
-    git add manifests/ops-files/non-precompiled-releases.yml
-    git commit -m "Bump $release to version $version in non-precompiled-releases ops-file"
+    git add "manifests/ops-files/$opsfile"
+    git commit -m "Bump $release to version $version in $opsfile"
 else
     echo "No changes to commit."
 fi

--- a/tasks/bump-boshrelease.yml
+++ b/tasks/bump-boshrelease.yml
@@ -9,6 +9,8 @@ run:
 params:
   REPO_URL:
   RELEASE_NAME:
+  OPSFILE:
+  MODE:
 inputs:
   - name: git-kubo-ci
   - name: git-kubo-deployment


### PR DESCRIPTION
**What this PR does / why we need it**:
The windows-tools-release and windows-utilities-release used on windows
nodes should be automatically updated. This generalizes the
bump-boshrelease.sh script to handle modifying the opsfile for adding
windows workers and adds these releases to bump-bosh-release.yml.

**How can this PR be verified?**
You can run the script locally and see it correctly modify the ops-files.

**Is there any change in kubo-release?**
No.

**Is there any change in kubo-deployment?**
Yes: https://github.com/cloudfoundry-incubator/kubo-deployment/pull/386

**Does this affect upgrade, or is there any migration required?**
No.

**Which issue(s) this PR fixes:**
Keeping windows-utilities-release and windows-tools-release up to date.

**Release note**:
```release-note
NONE
```
