### PR TITLE
[master] Extend the timeout of executing command inside emptydir-pod

### DIFF
--- a/src/tests/integration-tests/volume/emptydir_test.go
+++ b/src/tests/integration-tests/volume/emptydir_test.go
@@ -34,7 +34,7 @@ var _ = Describe("a pod emptyDir volume should be mounted under /var/vcap/data/k
 		It("should appear on the host under a /var/vcap/data/kubelet subdirectory", func() {
 			WaitForPodsToRun(kubectl, kubectl.TimeoutInSeconds*3)
 
-			Eventually(kubectl.StartKubectlCommand("exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]"), kubectl.TimeoutInSeconds*3).Should(gexec.Exit(0))
+			kubectl.RunKubectlCommandWithRetry(kubectl.Namespace(), kubectl.TimeoutInSeconds*3, "exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]")
 		})
 	})
 })

--- a/src/tests/integration-tests/volume/emptydir_test.go
+++ b/src/tests/integration-tests/volume/emptydir_test.go
@@ -34,7 +34,7 @@ var _ = Describe("a pod emptyDir volume should be mounted under /var/vcap/data/k
 		It("should appear on the host under a /var/vcap/data/kubelet subdirectory", func() {
 			WaitForPodsToRun(kubectl, kubectl.TimeoutInSeconds*3)
 
-			Eventually(kubectl.StartKubectlCommand("exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]"), kubectl.TimeoutInSeconds).Should(gexec.Exit(0))
+			Eventually(kubectl.StartKubectlCommand("exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]"), kubectl.TimeoutInSeconds*3).Should(gexec.Exit(0))
 		})
 	})
 })

--- a/src/tests/integration-tests/volume/emptydir_test.go
+++ b/src/tests/integration-tests/volume/emptydir_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	"github.com/onsi/gomega/gexec"
 )
 
@@ -28,13 +27,14 @@ var _ = Describe("a pod emptyDir volume should be mounted under /var/vcap/data/k
 		})
 
 		AfterEach(func() {
-			Eventually(kubectl.StartKubectlCommand("delete", "-f", podSpecPath), kubectl.TimeoutInSeconds).Should(gexec.Exit())
+			Eventually(kubectl.StartKubectlCommand("delete", "-f", podSpecPath), kubectl.TimeoutInSeconds*3).Should(gexec.Exit())
 		})
 
 		It("should appear on the host under a /var/vcap/data/kubelet subdirectory", func() {
 			WaitForPodsToRun(kubectl, kubectl.TimeoutInSeconds*3)
 
-			kubectl.RunKubectlCommandWithRetry(kubectl.Namespace(), kubectl.TimeoutInSeconds*3, "exec", "emptydir-pod", "--", "sh", "-c", "[ $(find /var/search -name find_me.txt | wc -l) -eq '1' ]")
+			output := kubectl.RunKubectlCommandWithRetry(kubectl.Namespace(), kubectl.TimeoutInSeconds*3, "exec", "emptydir-pod", "--", "sh", "-c", "find /var/search -name find_me.txt")
+			Expect(output).Should(ContainSubstring("simple-vol/find_me.txt"))
 		})
 	})
 })

--- a/src/tests/test_helpers/kubectl_runner.go
+++ b/src/tests/test_helpers/kubectl_runner.go
@@ -201,6 +201,7 @@ func (kubectl *KubectlRunner) getPodStatus(namespace string, selector ...string)
 // the command will retry every 10s
 // Expect the command output to be not empty
 // Expect the command to exit 0
+// return the command output
 func (kubectl *KubectlRunner) RunKubectlCommandWithRetry(namespace string, timeout float64, args ...string) string {
 	var session *gexec.Session
 

--- a/src/tests/test_helpers/kubectl_runner.go
+++ b/src/tests/test_helpers/kubectl_runner.go
@@ -187,20 +187,31 @@ func (kubectl *KubectlRunner) GetPodStatusBySelector(namespace string, selector 
 }
 
 func (kubectl *KubectlRunner) getPodStatus(namespace string, selector ...string) string {
-	var session *gexec.Session
 	args := []string{"describe", "pod"}
 	args = append(args, selector...)
+	output := kubectl.RunKubectlCommandWithRetry(namespace, kubectl.TimeoutInSeconds*2, args...)
+
+	re := regexp.MustCompile(`Status:\s+(\w+)`)
+	matches := re.FindStringSubmatch(output)
+	podStatus := matches[1]
+	return podStatus
+}
+
+// RunKubectlCommandWithRetry will run kubectl command with retries, until the timeout reaches
+// the command will retry every 10s
+// Expect the command output to be not empty
+// Expect the command to exit 0
+func (kubectl *KubectlRunner) RunKubectlCommandWithRetry(namespace string, timeout float64, args ...string) string {
+	var session *gexec.Session
+
 	Eventually(func() string {
-		session = kubectl.StartKubectlCommandInNamespace(namespace, args...)
+		kubectl.StartKubectlCommandInNamespace(namespace, args...)
 		Eventually(session, "10s").Should(gexec.Exit(0))
 
 		return string(session.Out.Contents())
-	}, kubectl.TimeoutInSeconds*2).ShouldNot(BeEmpty())
+	}, timeout).ShouldNot(BeEmpty())
 
-	re := regexp.MustCompile(`Status:\s+(\w+)`)
-	matches := re.FindStringSubmatch(string(session.Out.Contents()))
-	podStatus := matches[1]
-	return podStatus
+	return string(session.Out.Contents())
 }
 
 func (kubectl *KubectlRunner) GetLBAddress(service, iaas string) string {

--- a/src/tests/test_helpers/kubectl_runner.go
+++ b/src/tests/test_helpers/kubectl_runner.go
@@ -205,7 +205,7 @@ func (kubectl *KubectlRunner) RunKubectlCommandWithRetry(namespace string, timeo
 	var session *gexec.Session
 
 	Eventually(func() string {
-		kubectl.StartKubectlCommandInNamespace(namespace, args...)
+		session = kubectl.StartKubectlCommandInNamespace(namespace, args...)
 		Eventually(session, "10s").Should(gexec.Exit(0))
 
 		return string(session.Out.Contents())


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
Because with current timeout, the exec sometimes failed.
Seems like it's because exec happens before mounting succeed

**How can this PR be verified?**
running inside pks ci

**Is there any change in kubo-release?**
no
**Is there any change in kubo-deployment?**
no
**Does this affect upgrade, or is there any migration required?**
no
**Which issue(s) this PR fixes:**
https://pks.ci.cf-app.com/teams/main/pipelines/pks-api-deployment-1.3.x/jobs/run-integration-tests-azure/builds/213

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
