### PR TITLE
Explicitly specify release stemcell os/version combo

### DIFF
--- a/scripts/bump-precompiled-releases-in-manifest.sh
+++ b/scripts/bump-precompiled-releases-in-manifest.sh
@@ -28,6 +28,9 @@ cat >> bump-precompiled-releases.yml <<EOF
     version: $version
     sha1: $sha1
     url: $url
+    stemcell:
+      os: $stemcell_os
+      version: $stemcell_version
 EOF
 
 done


### PR DESCRIPTION
BOSH will get confused as to whether it already has downloaded a release if it's precompiled against a different stemcell

Fixes https://github.com/cloudfoundry-incubator/kubo-deployment/issues/394