### PR TITLE
Add task to check whether kubo release and kubo-deployment version ma…

### DIFF
--- a/scripts/check-version-match.sh
+++ b/scripts/check-version-match.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -exu -o pipefail
+
+main() {
+  kubo_release_version=$(cat kubo-release/version)
+  kubo_deployment_version=$(cat kubo-deployment/version)
+  if [ "$kubo_release_version" != "$kubo_deployment_version" ]; then
+    echo "kubo-release version: $kubo_release_version doesn't match kubo-deployment version: $kubo_deployment_version"
+    exit 1
+  fi
+}
+
+main @

--- a/tasks/check-version-match.yml
+++ b/tasks/check-version-match.yml
@@ -1,0 +1,13 @@
+platform: linux
+image_resource:
+  type: docker-image
+  source:
+    repository: pcfkubo/kubo-ci
+    tag: stable
+run:
+  path: git-kubo-ci/scripts/check-version-match.sh
+
+inputs:
+  - name: git-kubo-ci
+  - name: kubo-release
+  - name: kubo-deployment

--- a/templates/template.yml
+++ b/templates/template.yml
@@ -101,6 +101,9 @@ jobs:
   - get: kubo-deployment
     trigger: true
   - get: kubo-release
+  - get: git-kubo-ci
+  - task: check-version-match
+    file: git-kubo-ci/tasks/check-version-match.yml
   - put: kubo-lock
     params: { acquire: true }
 


### PR DESCRIPTION
…tches

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
Now when tests get triggered, it could happens that only kubo-release resource is updated, but kubo-deployment is not. So it's better to check the version before tests start

**How can this PR be verified?**
It's tested in one of the pipeline, which get deleted
**Is there any change in kubo-release?**

**Is there any change in kubo-deployment?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
