### PR TITLE
Bump ulimit to be same as GKE

### DIFF
--- a/src/tests/integration-tests/generic/ulimit_test.go
+++ b/src/tests/integration-tests/generic/ulimit_test.go
@@ -22,11 +22,11 @@ var _ = Describe("Ulimit", func() {
 		kubectl.Teardown()
 	})
 
-	It("Should have a ulimit at least of 65536", func() {
+	It("Should have a ulimit at least of 1048576", func() {
 		podName := test_helpers.GenerateRandomUUID()
 		output, err := kubectl.GetOutput("run", podName, "--image", "pcfkubo/ulimit", "--restart=Never", "-i", "--rm")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(strconv.Atoi(output[0])).To(BeNumerically(">=", 65536))
+		Expect(strconv.Atoi(output[0])).To(BeNumerically(">=", 1048576))
 	})
 
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
I would like to have better `ulimit` by default.

**How can this PR be verified?**

**Is there any change in kubo-release?**

**Is there any change in kubo-deployment?**
yes
https://github.com/cloudfoundry-incubator/kubo-deployment/pull/390

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
