### PR TITLE
Add ops-file for increasing bosh disk size

### DIFF
--- a/scripts/install-bosh.sh
+++ b/scripts/install-bosh.sh
@@ -33,6 +33,7 @@ if [[ ! -z ${USE_TURBULENCE+x} ]] && [[ ! -z "${USE_TURBULENCE}" ]]; then
 fi
 
 BOSH_EXTRA_OPS="${BOSH_EXTRA_OPS} --ops-file \"${ROOT}/git-bosh-deployment/jumpbox-user.yml\""
+BOSH_EXTRA_OPS="${BOSH_EXTRA_OPS} --ops-file \"${ROOT}/git-kubo-ci/change-bosh-disk-size.yml\""
 
 if [[ -f "$KUBO_CI_DIR/manifests/ops-files/${iaas}-cpi.yml" ]]; then
   BOSH_EXTRA_OPS="${BOSH_EXTRA_OPS} --ops-file $KUBO_CI_DIR/manifests/ops-files/${iaas}-cpi.yml"


### PR DESCRIPTION
Co-authored-by: Nick Tenczar <ntenczar@pivotal.io>
Co-authored-by: Larry Hamel <lhamel@pivotal.io>

**What this PR does / why we need it**:

use bigger disk for bosh: we filled one up with compilation products.

**How can this PR be verified?**

bosh has bigger disk

**Is there any change in kubo-release?**

No, CI only

**Is there any change in kubo-deployment?**

No, CI only

**Does this affect upgrade, or is there any migration required?**

No, CI only

**Which issue(s) this PR fixes:**

https://www.pivotaltracker.com/story/show/167772768

**Release note**:
NONE