### PR TITLE
Add docker-windows to list of jobs in exported release

### DIFF
--- a/build-kubo.yml
+++ b/build-kubo.yml
@@ -187,7 +187,7 @@ jobs:
         file: git-kubo-ci/tasks/export-release.yml
         params:
           RELEASE_LIST: "kubo"
-          JOBS_LIST: "flanneld-windows kube-proxy-windows kubelet-windows kubo-dns-aliases-windows"
+          JOBS_LIST: "flanneld-windows kube-proxy-windows kubelet-windows kubo-dns-aliases-windows docker-windows"
           stemcell_alias: windows
         input_mapping:
           gcs-source-json: gaffer-source-json


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds docker-windows job. Needed to avoid depending on https://github.com/cloudfoundry/windows-tools-release/ and since @srm09 said it was causing problems to have it in https://github.com/cloudfoundry-incubator/docker-boshrelease 

**Is there any change in kubo-deployment?**
https://github.com/cloudfoundry-incubator/kubo-deployment/pull/413

**Is there any change in kubo-release?**
https://github.com/cloudfoundry-incubator/kubo-release/pull/357

**Does this affect upgrade, or is there any migration required?**
No
