### PR TITLE
Allow setting multiple deployment configurations in v2_set_pipeline

### DIFF
--- a/v2_set_pipeline
+++ b/v2_set_pipeline
@@ -6,7 +6,7 @@ ci_dir="$(cd "$(dirname "$0")"; pwd)/templates"
 
 print_usage() {
   echo "Usage:" >&2
-  echo "    $0 <iaas> <deployment_configuration> [testcase] " >&2
+  echo "    $0 <iaas> <deployment_configurations...> [testcase] " >&2
   echo "" >&2
   echo "    valid iaas names:" >&2
   for name in "${ci_dir}"/iaas/*.yml; do
@@ -74,32 +74,44 @@ canonicalize_iaas_name() {
 }
 
 main() {
-  local deployment_configuration pipeline_config iaas_name testcase
-  if [ "$#" -gt "3" ] || [ "$#" == "0" ]  || [ "$#" == "1" ]; then
+  local deployment_configurations pipeline_config iaas_name testcase
+  if [[ $# -lt 2 ]]; then
     print_usage
     exit 1
   fi
   iaas_name=${1}
-  deployment_configuration=$(extract_deployment_configuration "${2}")
-  testcase=$(extract_testcase "${3}")
+  shift
+  while (( "$#" )); do
+    if [[ $# -eq 1 ]]; then
+      testcase=$(extract_testcase "${1}")
+      shift
+    else
+      deployment_configurations="${deployment_configurations} $(extract_deployment_configuration "${1}")"
+      shift
+    fi
+  done
 
   pipeline_config=$(cat "$ci_dir"/template.yml)
-  local deployment_configuration_ops_file="${ci_dir}/deployment-configurations/${deployment_configuration}.yml"
   local iaas_ops_file="${ci_dir}/iaas/${iaas_name}.yml"
   local testcase_ops_file="${ci_dir}/testcases/${testcase}.yml"
   local iaas_testcase_ops_file="${ci_dir}/iaas-testcase-ops-files/${iaas_name}-${testcase}.yml"
-  local iaas_deployment_configuration_ops_file="${ci_dir}/iaas-deployment-configuration-ops-files/${iaas_name}-${deployment_configuration}.yml"
-  if [ -f "${deployment_configuration_ops_file}" ]; then
-    pipeline_config=$(bosh int <(echo "${pipeline_config}") --ops-file "${deployment_configuration_ops_file}")
-  fi
+
+  for deployment_configuration in ${deployment_configurations}; do
+    local deployment_configuration_ops_file="${ci_dir}/deployment-configurations/${deployment_configuration}.yml"
+    local iaas_deployment_configuration_ops_file="${ci_dir}/iaas-deployment-configuration-ops-files/${iaas_name}-${deployment_configuration}.yml"
+    if [ -f "${deployment_configuration_ops_file}" ]; then
+      pipeline_config=$(bosh int <(echo "${pipeline_config}") --ops-file "${deployment_configuration_ops_file}")
+    fi
+    if [ -f "${iaas_deployment_configuration_ops_file}" ]; then
+      pipeline_config=$(bosh int <(echo "${pipeline_config}") --ops-file "${iaas_deployment_configuration_ops_file}")
+    fi
+  done
+
   if [ -f "${iaas_ops_file}" ]; then
     pipeline_config=$(bosh int <(echo "${pipeline_config}") --ops-file "${iaas_ops_file}")
   fi
   if [ -f "${testcase_ops_file}" ]; then
     pipeline_config=$(bosh int <(echo "${pipeline_config}") --ops-file "${testcase_ops_file}" -v iaas="${iaas_name}")
-  fi
-  if [ -f "${iaas_deployment_configuration_ops_file}" ]; then
-    pipeline_config=$(bosh int <(echo "${pipeline_config}") --ops-file "${iaas_deployment_configuration_ops_file}")
   fi
   if [ -f "${iaas_testcase_ops_file}" ]; then
     pipeline_config=$(bosh int <(echo "${pipeline_config}") --ops-file "${iaas_testcase_ops_file}")
@@ -107,12 +119,16 @@ main() {
 
   fly --target kubo sync > /dev/null
 
+  local joined_configurations="$(echo "${deployment_configurations}" | tr ' ' '_')"
+  local pipeline_name="${iaas_name}${joined_configurations}_${testcase}"
+
+  echo "Setting pipeline ${pipeline_name}"
   fly --target kubo set-pipeline \
     --config <(echo "${pipeline_config}") \
-    --pipeline "${iaas_name}_${deployment_configuration}_${testcase}" \
+    --pipeline "$pipeline_name" \
     -v locks="${iaas_name}" \
     -v iaas="$(canonicalize_iaas_name "${iaas_name}")" \
-    -v pipeline-name="${iaas_name}_${deployment_configuration}_${testcase}"
+    -v pipeline-name="$pipeline_name"
 }
 
 pushd "${ci_dir}" > /dev/null


### PR DESCRIPTION
Needed to support configuring network mode without duplicating windows_workers into `windows_workers_overlay` and `windows_workers_hostgw`.

This also means we can get rid of the empty "vanilla" configuration, since now 0 configurations are valid.

Eg:
./v2_set_pipeline gcp integration => gcp_integration
./v2_set_pipeline gcp windows-workers overlay integration => gcp_windows-workers_overlay_integration

Since this is gonna touch other people's workflows a little (though it should be entirely backwards compatible) I figured I'd get some review.

@vlad-stoian @professor 