### PR TITLE
Windows jobs edit the publish-version task input

### DIFF
--- a/templates/deployment-configurations/windows-workers.yml
+++ b/templates/deployment-configurations/windows-workers.yml
@@ -75,3 +75,12 @@
 - type: replace
   path: /jobs/name=run-tests/plan/task=run-tests/params?/ENABLE_WINDOWS_TESTS?
   value: true
+
+- type: replace
+  path: /jobs/name=publish-version/plan/metadata=in_parallel/in_parallel/get=kubo-release/get
+  value: kubo-release-windows
+
+- type: replace
+  path: /jobs/name=publish-version/plan/task=publish-version/input_mapping?
+  value:
+    kubo-release-windows: kubo-release

--- a/templates/deployment-configurations/windows-workers.yml
+++ b/templates/deployment-configurations/windows-workers.yml
@@ -76,11 +76,16 @@
   path: /jobs/name=run-tests/plan/task=run-tests/params?/ENABLE_WINDOWS_TESTS?
   value: true
 
+# the 0th element refers to the in_parallel gets, but there was no other way to refer to that element
 - type: replace
-  path: /jobs/name=publish-version/plan/metadata=in_parallel/in_parallel/get=kubo-release/get
+  path: /jobs/name=publish-version/plan/0/in_parallel/get=kubo-release/get
   value: kubo-release-windows
+
+- type: replace
+  path: /jobs/name=publish-version/plan/0/in_parallel/get=kubo-release-windows/passed
+  value: ["deploy-k8s"]
 
 - type: replace
   path: /jobs/name=publish-version/plan/task=publish-version/input_mapping?
   value:
-    kubo-release-windows: kubo-release
+    kubo-release: kubo-release-windows

--- a/templates/template.yml
+++ b/templates/template.yml
@@ -238,7 +238,8 @@ jobs:
 
 - name: publish-version
   plan:
-  - in_parallel:
+  - metadata: in_parallel
+    in_parallel:
     - get: git-kubo-ci
     - get: gcs-shipable-version
     - get: kubo-deployment

--- a/templates/template.yml
+++ b/templates/template.yml
@@ -238,8 +238,7 @@ jobs:
 
 - name: publish-version
   plan:
-  - metadata: in_parallel
-    in_parallel:
+  - in_parallel:
     - get: git-kubo-ci
     - get: gcs-shipable-version
     - get: kubo-deployment


### PR DESCRIPTION
Authored-by: Daniel Keeney <dkeeney@pivotal.io>

**What this PR does / why we need it**:
This adjusts the inputs (and hopefully the outputs) of the windows-workers pipelines so that signals-aggregator can have the correct inputs.

**How can this PR be verified?**
Fly and run https://ci.kubo.sh/teams/main/pipelines/vsphere_windows-workers_integration

**Is there any change in kubo-release?**'
No

**Is there any change in kubo-deployment?**
No

**Does this affect upgrade, or is there any migration required?**
No
