### PR TITLE
Remove dashboard references

### DIFF
--- a/src/tests/integration-tests/generic/dns_test.go
+++ b/src/tests/integration-tests/generic/dns_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Kubernetes DNS", func() {
 			return kubectl.GetPodStatus("kube-system", "busybox")
 		}, kubectl.TimeoutInSeconds).Should(Equal("Running"))
 
-		session := kubectl.StartKubectlCommandInNamespace("kube-system", "exec", "busybox", "--", "nslookup", "kubernetes-dashboard.kube-system.svc.cluster.local")
+		session := kubectl.StartKubectlCommandInNamespace("kube-system", "exec", "busybox", "--", "nslookup", "metrics-server.kube-system.svc.cluster.local")
 		Eventually(session, kubectl.TimeoutInSeconds*2).Should(gexec.Exit(0))
 	})
 })

--- a/src/tests/integration-tests/generic/kubectl_test.go
+++ b/src/tests/integration-tests/generic/kubectl_test.go
@@ -51,56 +51,6 @@ var _ = Describe("Kubectl", func() {
 		}, "300s", "10s").Should(Equal(0))
 	})
 
-	Context("Dashboard", func() {
-		It("Should provide access to the dashboard via kubectl proxy", func() {
-			session := kubectl.StartKubectlCommand("proxy")
-			Eventually(session).Should(gbytes.Say("Starting to serve on"))
-
-			timeout := time.Duration(5 * time.Second)
-			httpClient := http.Client{
-				Timeout: timeout,
-			}
-
-			// For more details, see: https://github.com/kubernetes/dashboard/wiki/Accessing-Dashboard---1.7.X-and-above#kubectl-proxy
-			appUrl := "http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/"
-
-			Eventually(func() int {
-				result, err := httpClient.Get(appUrl)
-				if err != nil {
-					return -1
-				}
-				return result.StatusCode
-			}, kubectl.TimeoutInSeconds*2, "5s").Should(Equal(200))
-
-			session.Terminate()
-		})
-
-		It("Should provide access to the dashboard via a node port", func() {
-
-			timeout := time.Duration(5 * time.Second)
-			transport := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			}
-			httpClient := http.Client{
-				Timeout:   timeout,
-				Transport: transport,
-			}
-
-			appAddress := kubectl.GetAppAddressInNamespace("svc/kubernetes-dashboard", "kube-system")
-			appUrl := fmt.Sprintf("https://%s", appAddress)
-
-			Eventually(func() int {
-				result, err := httpClient.Get(appUrl)
-				if err != nil {
-					return -1
-				}
-				return result.StatusCode
-			}, kubectl.TimeoutInSeconds*2, "5s").Should(Equal(200))
-		})
-	})
-
 	Context("When unauthorized service account", func() {
 		var serviceAccount string
 


### PR DESCRIPTION
Dashboard is getting removed since it has an unpatched vulnerability.
Use metrics-server as a DNS reference instead, when testing DNS.
