### PR TITLE
Add windows volume test

### DIFF
--- a/specs/windows/stateful-set-windows.yml
+++ b/specs/windows/stateful-set-windows.yml
@@ -1,0 +1,41 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: windows-pv
+spec:
+  selector:
+    matchLabels:
+      app: windows-pv
+  serviceName: "windows-pv-svc"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: windows-pv
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: windows-pv
+        image: mcr.microsoft.com/windows/servercore:1809
+        command: ["ping", "-t", "localhost"]
+        volumeMounts:
+        - name: www
+          mountPath: "c:\\var\\run"
+      nodeSelector:
+        beta.kubernetes.io/os: windows
+      tolerations:
+      - key: "windows"
+        operator: "Equal"
+        value: "2019"
+        effect: "NoSchedule"
+      restartPolicy: Always
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: ci-storage
+      resources:
+        requests:
+          storage: 1Gi

--- a/specs/windows/storage-class-vsphere-windows.yml
+++ b/specs/windows/storage-class-vsphere-windows.yml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ci-storage
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+  diskformat: thin
+  fstype: NTFS

--- a/src/tests/integration-tests/windows/windows_volume_test.go
+++ b/src/tests/integration-tests/windows/windows_volume_test.go
@@ -22,7 +22,7 @@ var _ = Describe("When deploying to a Windows worker", func() {
 		kubectl.Setup()
 		Eventually(kubectl.StartKubectlCommand("create", "-f", storageClassSpec), "60s").Should(gexec.Exit(0))
 		Eventually(kubectl.StartKubectlCommand("create", "-f", statefulSetSpec), "60s").Should(gexec.Exit(0))
-		Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulesets/windows-pv"), "600s").Should(gexec.Exit(0))
+		Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulset/windows-pv"), "600s").Should(gexec.Exit(0))
 	})
 
 	AfterEach(func() {
@@ -43,10 +43,10 @@ var _ = Describe("When deploying to a Windows worker", func() {
 
 				By("recreate pod")
 				Eventually(kubectl.StartKubectlCommand("delete", "po", "windows-pv-0"), "60s").Should(gexec.Exit(0))
-				Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulesets/windows-pv"), "60s").Should(gexec.Exit(0))
+				Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulset/windows-pv"), "60s").Should(gexec.Exit(0))
 
 				By("check file")
-				Eventually(kubectl.StartKubectlCommand("kubectl", "exec", "windows-pv-0", "powershell",
+				Eventually(kubectl.StartKubectlCommand("exec", "windows-pv-0", "powershell",
 					"dir c:\\var\\run\\testfile1.txt"), "60s").Should(gexec.Exit(0))
 			})
 		})

--- a/src/tests/integration-tests/windows/windows_volume_test.go
+++ b/src/tests/integration-tests/windows/windows_volume_test.go
@@ -1,0 +1,50 @@
+package windows_test
+
+import (
+	"tests/test_helpers"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var (
+	storageClassSpec = test_helpers.PathFromRoot("specs/windows/storage-class-vsphere-windows.yml")
+	statefulSetSpec  = test_helpers.PathFromRoot("specs/windows/stateful-set-windows.yml")
+)
+
+var _ = Describe("When deploying to a Windows worker", func() {
+	BeforeEach(func() {
+		if !hasWindowsWorkers {
+			Skip("skipping Windows tests since no Windows nodes were detected")
+		}
+		kubectl = test_helpers.NewKubectlRunner()
+		kubectl.Setup()
+		Eventually(kubectl.StartKubectlCommand("create", "-f", storageClassSpec), "60s").Should(gexec.Exit(0))
+		Eventually(kubectl.StartKubectlCommand("create", "-f", statefulSetSpec), "60s").Should(gexec.Exit(0))
+		Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulesets/windows-pv"), "600s").Should(gexec.Exit(0))
+	})
+
+	AfterEach(func() {
+		kubectl.Teardown()
+	})
+
+	Context("when a file is saved to folder in PV", func() {
+		Context("when a pod is recreated", func() {
+			It("should be able to read the previous created file from PV", func() {
+				By("Save file to pv")
+				Eventually(kubectl.StartKubectlCommand("exec", "windows-pv-0", "powershell",
+					"New-Item -Path 'c:\\var\\run\\' -Name 'testfile1.txt' -ItemType 'file' -Value 'This is a text string.'"),
+					"60s").Should(gexec.Exit(0))
+
+				By("recreate pod")
+				Eventually(kubectl.StartKubectlCommand("delete", "po", "windows-pv-0"), "60s").Should(gexec.Exit(0))
+				Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulesets/windows-pv"), "60s").Should(gexec.Exit(0))
+
+				By("check file")
+				Eventually(kubectl.StartKubectlCommand("kubectl", "exec", "windows-pv-0", "powershell",
+					"dir c:\\var\\run\\testfile1.txt"), "60s").Should(gexec.Exit(0))
+			})
+		})
+	})
+})

--- a/src/tests/integration-tests/windows/windows_volume_test.go
+++ b/src/tests/integration-tests/windows/windows_volume_test.go
@@ -26,6 +26,10 @@ var _ = Describe("When deploying to a Windows worker", func() {
 	})
 
 	AfterEach(func() {
+		Eventually(kubectl.StartKubectlCommand("delete", "-f", statefulSetSpec), kubectl.TimeoutInSeconds).Should(gexec.Exit())
+		Eventually(kubectl.StartKubectlCommand("delete", "pvc", "--all"), kubectl.TimeoutInSeconds).Should(gexec.Exit())
+		Eventually(kubectl.StartKubectlCommand("delete", "pv", "--all"), kubectl.TimeoutInSeconds).Should(gexec.Exit())
+		Eventually(kubectl.StartKubectlCommand("delete", "-f", storageClassSpec), kubectl.TimeoutInSeconds).Should(gexec.Exit())
 		kubectl.Teardown()
 	})
 

--- a/src/tests/integration-tests/windows/windows_volume_test.go
+++ b/src/tests/integration-tests/windows/windows_volume_test.go
@@ -43,7 +43,7 @@ var _ = Describe("When deploying to a Windows worker", func() {
 
 				By("recreate pod")
 				Eventually(kubectl.StartKubectlCommand("delete", "po", "windows-pv-0"), "60s").Should(gexec.Exit(0))
-				Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulset/windows-pv"), "60s").Should(gexec.Exit(0))
+				Eventually(kubectl.StartKubectlCommand("rollout", "status", "statefulset/windows-pv"), "120s").Should(gexec.Exit(0))
 
 				By("check file")
 				Eventually(kubectl.StartKubectlCommand("exec", "windows-pv-0", "powershell",


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->
https://www.pivotaltracker.com/story/show/172801972
This is for testing windows PV workload on vsphere flannel. Will also add tests to raas for vsphere nsx

The test first create statefulset, then write a file to the path that mount to PV, then recreate the pod, check if the file still exist

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/dev/pipelines/pks-api-test-windows-pv/jobs/run-integration-tests-vsphere-windows/builds/7#L5edf4930:793
**Is there any change in kubo-release?**
no
**Is there any change in kubo-deployment?**
no
**Does this affect upgrade, or is there any migration required?**
no
**Which issue(s) this PR fixes:**
https://www.pivotaltracker.com/story/show/172801972
**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
