### PR TITLE
Pin image stefanscherer/webserver-windows to 0.4.0

### DIFF
--- a/specs/windows/webserver.yml
+++ b/specs/windows/webserver.yml
@@ -15,7 +15,7 @@ spec:
     effect: "NoSchedule"
   restartPolicy: Always
   containers:
-  - image: stefanscherer/webserver-windows:latest
+  - image: stefanscherer/webserver-windows:0.4.0
     name: webserver
     env:
     - name: PORT


### PR DESCRIPTION
# Problem
Saw this error during the deployment of windows image `stefanscherer/webserver-windows:latest`
https://pks.ci.cf-app.com/teams/main/pipelines/pks-api-1.9.x/jobs/run-integration-tests-vsphere-windows/builds/42
```
Events:
  Type     Reason                  Age               From                                           Message
  ----     ------                  ----              ----                                           -------
  Normal   Scheduled               <unknown>         default-scheduler                              Successfully assigned default/webserver-windows-7997dd8cb6-4frqg to 9a10024a-5bb2-4540-84f7-e5cb2088ee60
  Warning  FailedCreatePodSandBox  24s               kubelet, 9a10024a-5bb2-4540-84f7-e5cb2088ee60  Failed to create pod sandbox: rpc error: code = Unknown desc = [failed to set up sandbox container "f337fbc895045dd8318efda9b1e9cef284f4084aa73b8781f3e80264c1591575" network for pod "webserver-windows-7997dd8cb6-4frqg": networkPlugin cni failed to set up pod "webserver-windows-7997dd8cb6-4frqg_default" network: error while ProvisionEndpoint(f337fbc895045dd8318efda9b1e9cef284f4084aa73b8781f3e80264c1591575_cbr0,30F63AE9-9D03-44F0-BC31-A7FE2EA4C51B,f337fbc895045dd8318efda9b1e9cef284f4084aa73b8781f3e80264c1591575): failed to create the new HNSEndpoint: hnsCall failed in Win32: The object already exists. (0x1392), failed to clean up sandbox container "f337fbc895045dd8318efda9b1e9cef284f4084aa73b8781f3e80264c1591575" network for pod "webserver-windows-7997dd8cb6-4frqg": networkPlugin cni failed to teardown pod "webserver-windows-7997dd8cb6-4frqg_default" network: failed to find HNSEndpoint f337fbc895045dd8318efda9b1e9cef284f4084aa73b8781f3e80264c1591575_cbr0: Endpoint f337fbc895045dd8318efda9b1e9cef284f4084aa73b8781f3e80264c1591575_cbr0 not found]
  Normal   SandboxChanged          23s               kubelet, 9a10024a-5bb2-4540-84f7-e5cb2088ee60  Pod sandbox changed, it will be killed and re-created.
  Warning  Failed                  20s               kubelet, 9a10024a-5bb2-4540-84f7-e5cb2088ee60  Error: ImagePullBackOff
  Normal   Pulling                 8s (x2 over 22s)  kubelet, 9a10024a-5bb2-4540-84f7-e5cb2088ee60  Pulling image "stefanscherer/webserver-windows:latest"
  Warning  Failed                  7s (x2 over 21s)  kubelet, 9a10024a-5bb2-4540-84f7-e5cb2088ee60  Failed to pull image "stefanscherer/webserver-windows:latest": rpc error: code = Unknown desc = a Windows version 10.0.19041-based image is incompatible with a 10.0.17763 host
```

# Why is this a problem?
Turns out the image was updated yesterday 
https://hub.docker.com/r/stefanscherer/webserver-windows/tags
We should pin our image to tag `0.4.0`

# Completion Criteria
Pin the tag to `0.4.0`