### PR TITLE
Remove parameter --generator to support kubernetes 1.21

### DIFF
--- a/src/tests/integration-tests/k8s_lbs/internal_loadbalancers_test.go
+++ b/src/tests/integration-tests/k8s_lbs/internal_loadbalancers_test.go
@@ -30,7 +30,6 @@ var _ = Describe("Internal load balancers", func() {
 		Eventually(func() int {
 			session := kubectl.StartKubectlCommand("run",
 				"test-master-cert-via-curl",
-				"--generator=run-pod/v1",
 				"--image=gcr.io/cf-pks-golf/tutum/curl",
 				"--restart=Never",
 				"-ti",

--- a/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
+++ b/src/tests/integration-tests/scaling/horizontal_pod_autoscaling_test.go
@@ -68,7 +68,7 @@ func createHPADeployment() {
 func increaseCPULoad() {
 	remoteCommand := "while true; do wget -q -O- http://php-apache; done"
 
-	session := kubectl.StartKubectlCommand("run", "-i", "--tty", "load-generator", "--generator=run-pod/v1", "--image=gcr.io/cf-pks-golf/busybox", "--", "/bin/sh", "-c", remoteCommand)
+	session := kubectl.StartKubectlCommand("run", "-i", "--tty", "load-generator", "--image=gcr.io/cf-pks-golf/busybox", "--", "/bin/sh", "-c", remoteCommand)
 	Eventually(session, "10s").Should(gexec.Exit(0))
 
 	Eventually(func() string {


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/main/pipelines/pks-api-1.12.x
**Is there any change in kubo-release?**

**Is there any change in kubo-deployment?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
