### PR TITLE
skip curl service for windows-flannel env

### DIFF
--- a/src/tests/integration-tests/windows/windows_test.go
+++ b/src/tests/integration-tests/windows/windows_test.go
@@ -78,6 +78,7 @@ var _ = Describe("When deploying to a Windows worker", func() {
 		})
 
 		By("should be able to reach it via Cluster IP", func() {
+			Skip("Skip test because issue: https://jira.eng.vmware.com/browse/PKS-5833")
 			clusterIP := kubectl.GetOutputBytes("get", "service", "windows-webserver",
 				"-o", "jsonpath='{.spec.clusterIP}'")
 			url := fmt.Sprintf("http://%s", clusterIP)


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

Same pr with https://github.com/cloudfoundry-incubator/kubo-ci/pull/126

**How can this PR be verified?**

**Is there any change in kubo-release?**

**Is there any change in kubo-deployment?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
