### PR TITLE
CSI storage class for windows does not supprt -parameters:

### DIFF
--- a/specs/windows/storage-class-vsphere-windows.yml
+++ b/specs/windows/storage-class-vsphere-windows.yml
@@ -3,6 +3,3 @@ kind: StorageClass
 metadata:
   name: ci-storage
 provisioner: kubernetes.io/vsphere-volume
-parameters:
-  diskformat: thin
-  fstype: NTFS


### PR DESCRIPTION
CSI storage class for windows does not supprt -parameters:
-  diskformat: thin
-  fstype: NTFS

**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**

**Is there any change in kubo-release?**

**Is there any change in kubo-deployment?**

**Does this affect upgrade, or is there any migration required?**

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
